### PR TITLE
Allow call_number to be added as advanced search field

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,8 @@ Or install it yourself as:
 
 Once installed in your Argon app some setup is required to enable call number searching.
 
-In `app/models/search_builder.rb` add `include ArgonCallNumberSearch::SearchBuilderBehavior` and add the `add_call_number_query_to_solr` method to the default processor chain.
+In `app/models/search_builder.rb` add `include ArgonCallNumberSearch::SearchBuilderBehavior` and add the `add_call_number_query_to_solr` method to the default processor chain, 
+after `add_advanced_search_to_solr` if using Blacklight's `AdvancedSearchBuilder`.
 
 For example:
 
@@ -31,7 +32,8 @@ class SearchBuilder < Blacklight::SearchBuilder
   include Blacklight::Solr::SearchBuilderBehavior
   include ArgonCallNumberSearch::SearchBuilderBehavior
 
-  self.default_processor_chain += %i[add_call_number_query_to_solr]
+  self.default_processor_chain += %i[add_advanced_search_to_solr
+                                     add_call_number_query_to_solr]
 end
 ```
 
@@ -50,7 +52,6 @@ class CatalogController < ApplicationController
     config.add_search_field('call_number') do |field|
       field.label = I18n.t('trln_argon.search_fields.call_number')
       field.advanced_parse = false
-      field.include_in_advanced_search = false
     end
 
     # SNIP

--- a/lib/argon_call_number_search/version.rb
+++ b/lib/argon_call_number_search/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module ArgonCallNumberSearch
-  VERSION = '0.1.1'
+  VERSION = '0.1.2'
 end

--- a/spec/argon_call_number_search/search_builder_behavior_spec.rb
+++ b/spec/argon_call_number_search/search_builder_behavior_spec.rb
@@ -28,35 +28,86 @@ RSpec.describe ArgonCallNumberSearch::SearchBuilderBehavior do
   end
 
   describe 'lc call number search' do
-    let(:blacklight_parameters) do
-      { 'search_field' => 'call_number',
-        :q => 'PS3623.I556497 P433' }
-    end
+    context 'call number search' do
+      let(:blacklight_parameters) do
+        { :search_field => 'call_number',
+          :q => 'PS3623.I556497 P433' }
+      end
 
-    it 'generates a solr query' do
-      expect(SearchBuilder.add_call_number_query_to_solr(solr_parameters)).to(
-        eq('lc_call_nos_normed_a:/PS.3623.I556497.P433(\\..*|-.*)*/ OR ' \
+      it 'generates a solr query' do
+        expect(SearchBuilder.add_call_number_query_to_solr(solr_parameters)).to(
+            eq('lc_call_nos_normed_a:/PS.3623.I556497.P433(\\..*|-.*)*/ OR ' \
            'shelfkey:/lc:PS.3623.I556497.P433(\\..*|-.*)*/ OR ' \
            '_query_:"{!edismax qf=shelf_numbers_tp pf= pf3= pf2=}' \
            '(PS3623.I556497 P433)"')
-      )
+        )
+      end
+    end
+
+    context 'advanced search' do
+      let(:blacklight_parameters) do
+        { :search_field => 'advanced',
+          :title => 'meditations',
+          :call_number => 'PS3623.I556497 P433',
+          :op => 'AND' }
+      end
+      let(:solr_parameters) do # solr_parameters from advanced search
+        { :q => "_query_:\"{!edismax qf=$title_qf pf=$title_pf pf3=$title_pf3 pf2=$title_pf2}" \
+                "#{blacklight_parameters[:title]}\" AND _query_:\"{!edismax}#{blacklight_parameters[:call_number]}\"" }
+      end
+
+      it 'generates a solr query' do
+        expect(SearchBuilder.add_call_number_query_to_solr(solr_parameters)).to(
+            eq('_query_:"{!edismax qf=$title_qf pf=$title_pf pf3=$title_pf3 pf2=$title_pf2}meditations" AND ' \
+           '(lc_call_nos_normed_a:/PS.3623.I556497.P433(\\..*|-.*)*/ OR ' \
+           'shelfkey:/lc:PS.3623.I556497.P433(\\..*|-.*)*/ OR ' \
+           '_query_:"{!edismax qf=shelf_numbers_tp pf= pf3= pf2=}' \
+           '(PS3623.I556497 P433)")')
+        )
+      end
     end
   end
 
   describe 'accession number search' do
-    let(:blacklight_parameters) do
-      { 'search_field' => 'call_number',
-        :q => 'cd 12345' }
+    context 'call number search' do
+      let(:blacklight_parameters) do
+        { :search_field => 'call_number',
+          :q => 'cd 12345' }
+      end
+
+      it 'generates a solr query' do
+        expect(SearchBuilder.add_call_number_query_to_solr(solr_parameters)).to(
+          eq('lc_call_nos_normed_a:/cd 12345(\\..*|-.*)*/ OR '\
+             'shelfkey:/lc:cd 12345(\\..*|-.*)*/ OR '\
+             '_query_:"{!edismax qf=shelf_numbers_tp pf= pf3= pf2=}'\
+             '(cd 12345)" OR '\
+             '_query_:"{!edismax qf=shelf_numbers_tp pf= pf3= pf2=}(cd12345)"')
+        )
+      end
     end
 
-    it 'generates a solr query' do
-      expect(SearchBuilder.add_call_number_query_to_solr(solr_parameters)).to(
-        eq('lc_call_nos_normed_a:/cd 12345(\\..*|-.*)*/ OR '\
+    context 'advanced search' do
+      let(:blacklight_parameters) do
+        { :search_field => 'advanced',
+          :title => 'ballad',
+          :call_number => 'cd 12345',
+          :op => 'OR' }
+      end
+      let(:solr_parameters) do # solr_parameters from advanced search
+        { :q => "_query_:\"{!edismax qf=$title_qf pf=$title_pf pf3=$title_pf3 pf2=$title_pf2}" \
+                "#{blacklight_parameters[:title]}\" OR _query_:\"{!edismax}#{blacklight_parameters[:call_number]}\"" }
+      end
+
+      it 'generates a solr query' do
+        expect(SearchBuilder.add_call_number_query_to_solr(solr_parameters)).to(
+            eq('_query_:"{!edismax qf=$title_qf pf=$title_pf pf3=$title_pf3 pf2=$title_pf2}ballad" OR ' \
+           '(lc_call_nos_normed_a:/cd 12345(\\..*|-.*)*/ OR '\
            'shelfkey:/lc:cd 12345(\\..*|-.*)*/ OR '\
            '_query_:"{!edismax qf=shelf_numbers_tp pf= pf3= pf2=}'\
            '(cd 12345)" OR '\
-           '_query_:"{!edismax qf=shelf_numbers_tp pf= pf3= pf2=}(cd12345)"')
-      )
+           '_query_:"{!edismax qf=shelf_numbers_tp pf= pf3= pf2=}(cd12345)")')
+        )
+      end
     end
   end
 end


### PR DESCRIPTION
This PR allows the call_number search field to be added to the Advanced Search form. TRLN institutions can choose to add the field to Advanced Search by setting `field.include_in_advanced_search = false` when defining the field in `catalog_controller.rb`.

Basically just overrides call_number handling from blacklight advanced search with ArgonCallNumberSearch builder logic (updated README to note that `add_call_number_query_to_solr` needs to be added after `add_advanced_search_to_solr` in SearchBuilder processor chain).

Run `bundle exec rake release` after merging this to master.